### PR TITLE
Improved climate component behaviour

### DIFF
--- a/components/otgw/__init__.py
+++ b/components/otgw/__init__.py
@@ -14,14 +14,12 @@ AUTO_LOAD = ["sensor", "text_sensor", "binary_sensor", "climate"]
 otgw_ns = cg.esphome_ns.namespace('otgw')
 OpenthermGateway = otgw_ns.class_('OpenthermGateway', uart.UARTDevice, cg.Component)
 
-CONF_OVERRIDE_THERMOSTAT = "override_thermostat"
 CONF_OUTSIDE_TEMPERATURE = "outside_temperature"
 CONF_TIME_SOURCE = "time_source"
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(OpenthermGateway),
 
-    cv.Optional(CONF_OVERRIDE_THERMOSTAT): cv.boolean,
     cv.Optional(CONF_OUTSIDE_TEMPERATURE): cv.use_id(sensor.Sensor),
     cv.Optional(CONF_TIME_SOURCE): cv.use_id(time.RealTimeClock),
 }).extend(uart.UART_DEVICE_SCHEMA)
@@ -37,8 +35,5 @@ async def to_code(config):
     if CONF_TIME_SOURCE in config:
         sens = await cg.get_variable(config[CONF_TIME_SOURCE])
         cg.add(var.set_time_source(sens));
-
-    if CONF_OVERRIDE_THERMOSTAT in config:
-        cg.add(var.set_override_thermostat(config[CONF_OVERRIDE_THERMOSTAT]))
 
     await cg.register_component(var, config)

--- a/components/otgw/button.py
+++ b/components/otgw/button.py
@@ -9,6 +9,7 @@ from . import OpenthermGateway, CONF_OTGW_ID, otgw_ns
 AUTO_LOAD = ["otgw"]
 
 CONF_RESET_SERVICE_REQUEST = "reset_service_request"
+CONF_HOT_WATER_PUSH = "hot_water_push"
 
 OpenthermGatewayButton = otgw_ns.class_("OpenthermGatewayButton", button.Button)
 
@@ -16,6 +17,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(CONF_OTGW_ID): cv.use_id(OpenthermGateway),
 
     cv.Optional(CONF_RESET_SERVICE_REQUEST): button.button_schema(OpenthermGatewayButton),
+    cv.Optional(CONF_HOT_WATER_PUSH): button.button_schema(OpenthermGatewayButton),
 })
 
 async def to_code(config):
@@ -24,3 +26,6 @@ async def to_code(config):
     if CONF_RESET_SERVICE_REQUEST in config:
         var = await button.new_button(config[CONF_RESET_SERVICE_REQUEST])
         cg.add(hub.set_reset_service_request_button(var))
+    if CONF_HOT_WATER_PUSH in config:
+        var = await button.new_button(config[CONF_HOT_WATER_PUSH])
+        cg.add(hub.set_hot_water_push_button(var))

--- a/components/otgw/climate.cpp
+++ b/components/otgw/climate.cpp
@@ -6,7 +6,7 @@ namespace otgw {
 OpenthermGatewayClimate::OpenthermGatewayClimate(float max_temperature, bool off_supported)
     : _off_supported(off_supported) {
   _traits.set_supports_current_temperature(true);
-  _traits.set_supported_modes({climate::CLIMATE_MODE_HEAT});
+  _traits.set_supported_modes({climate::CLIMATE_MODE_AUTO, climate::CLIMATE_MODE_HEAT});
   if (off_supported) {
     _traits.add_supported_mode(climate::CLIMATE_MODE_OFF);
   }
@@ -16,17 +16,21 @@ OpenthermGatewayClimate::OpenthermGatewayClimate(float max_temperature, bool off
   _traits.set_visual_temperature_step(0.01);
 
   if (!off_supported) {
-    this->set_mode(climate::CLIMATE_MODE_HEAT);
+    // TODO: get this value from memory
+    this->set_mode(climate::CLIMATE_MODE_AUTO);
   }
 }
 
 void OpenthermGatewayClimate::control(const climate::ClimateCall &call) {
   bool publish = false;
 
+  // TODO: It might be better to only publish once OTGW confirms the change. It depends on how this would affect interaction in Home Assistant.
+
   if (call.get_mode().has_value()) {
     auto new_mode = *call.get_mode();
     if (new_mode != climate::CLIMATE_MODE_OFF || _off_supported) {
       this->mode = new_mode;
+      _mode_callback();
     }
 
     publish = true;
@@ -34,28 +38,17 @@ void OpenthermGatewayClimate::control(const climate::ClimateCall &call) {
 
   if (call.get_target_temperature().has_value()) {
     this->target_temperature = *call.get_target_temperature();
+    _target_callback();
     publish = true;
   }
 
   if (publish) {
-    optional<float> state;
-    if (this->mode == climate::CLIMATE_MODE_HEAT) {
-      state = this->target_temperature;
-    }
-    _callback(state);
-
     this->publish_state();
   }
 }
 
 void OpenthermGatewayClimate::set_cooling_supported(bool supported) {
-  _traits.set_supported_modes({climate::CLIMATE_MODE_HEAT});
-  if (_off_supported) {
-    _traits.add_supported_mode(climate::CLIMATE_MODE_OFF);
-  }
-  if (supported) {
-    _traits.add_supported_mode(climate::CLIMATE_MODE_COOL);
-  }
+  // TODO: Add support for cooling. there was some support before, but we should really make sure it is supported properly
 }
 
 void OpenthermGatewayClimate::set_target_temperature(float temperature) {
@@ -82,8 +75,12 @@ void OpenthermGatewayClimate::set_mode(climate::ClimateMode mode) {
   this->publish_state();
 }
 
-void OpenthermGatewayClimate::set_callback(decltype(OpenthermGatewayClimate::_callback) &&callback) {
-  _callback = callback;
+void OpenthermGatewayClimate::set_callbacks(
+  decltype(OpenthermGatewayClimate::_target_callback) &&target_callback,
+  decltype(OpenthermGatewayClimate::_mode_callback) &&mode_callback
+) {
+  _target_callback = target_callback;
+  _mode_callback = mode_callback;
 }
 
 climate::ClimateTraits OpenthermGatewayClimate::traits() { return _traits; }

--- a/components/otgw/climate.h
+++ b/components/otgw/climate.h
@@ -7,7 +7,8 @@ namespace otgw {
 
 class OpenthermGatewayClimate : public Component, public climate::Climate {
  protected:
-  std::function<void(optional<float>)> _callback;
+  std::function<void()> _target_callback;
+  std::function<void()> _mode_callback;
   climate::ClimateTraits _traits;
   bool _off_supported;
 
@@ -24,7 +25,7 @@ class OpenthermGatewayClimate : public Component, public climate::Climate {
   void set_mode(climate::ClimateMode mode);
   void set_action(climate::ClimateAction action);
 
-  void set_callback(decltype(_callback) &&callback);
+  void set_callbacks(decltype(_target_callback) &&target_callback, decltype(_mode_callback) &&mode_callback);
 
   climate::ClimateTraits traits() override;
 };

--- a/components/otgw/otgw.cpp
+++ b/components/otgw/otgw.cpp
@@ -522,7 +522,7 @@ void OpenthermGateway::set_room_thermostat(OpenthermGatewayClimate *clim) {
         queue_command("TT", parameter);
         break;
       default:
-        ESP_LOGE("otgw", "Invalid climate mode for heating circuit %s", heating_circuit->enable_command);
+        ESP_LOGE("otgw", "Invalid climate mode for room thermostat");
         break;
     }
   };

--- a/components/otgw/otgw.cpp
+++ b/components/otgw/otgw.cpp
@@ -219,8 +219,13 @@ void OpenthermGateway::parse_line(std::string const &line) {
       }
 
       bool master_water_heating = master_bits[1];
+      bool master_block_hot_water = master_bits[6];
       if (_hot_water != nullptr) {
-        _hot_water->set_mode(master_water_heating ? climate::CLIMATE_MODE_HEAT : climate::CLIMATE_MODE_OFF);
+        climate::ClimateMode mode = climate::CLIMATE_MODE_OFF;
+        if (!master_block_hot_water) {
+          mode = master_water_heating ? climate::CLIMATE_MODE_HEAT : climate::CLIMATE_MODE_AUTO;
+        }
+        _hot_water->set_mode(mode);
       }
 
       this->master_central_heating_1.publish_state(master_central_heating_1);

--- a/components/otgw/otgw.cpp
+++ b/components/otgw/otgw.cpp
@@ -339,6 +339,11 @@ void OpenthermGateway::parse_line(std::string const &line) {
       if (_heating_circuit_1) {
         _heating_circuit_1->heating_circuit->set_current_temperature(temperature);
       }
+
+      // Some boilers do not report the hot water temperature. In that case we can take the overall temperature.
+      if (_hot_water && !_hot_water_temperature_reported) {
+        _hot_water->set_current_temperature(temperature);
+      }
       break;
     }
     case 31: {
@@ -353,6 +358,8 @@ void OpenthermGateway::parse_line(std::string const &line) {
     case 26: {
       float temperature = parse_float(data);
       this->hot_water_temperature_1.publish_state(temperature);
+
+      _hot_water_temperature_reported = true;
 
       if (_hot_water != nullptr) {
         _hot_water->set_current_temperature(temperature);

--- a/components/otgw/otgw.cpp
+++ b/components/otgw/otgw.cpp
@@ -594,8 +594,6 @@ void OpenthermGateway::set_heating_circuit_2(OpenthermGatewayClimate *clim) {
   });
 }
 
-void OpenthermGateway::set_override_thermostat(bool value) { _override_thermostat = value; }
-
 void OpenthermGateway::set_outside_temperature_override(sensor::Sensor *sens) {
   _outside_temperature_override = sens;
   _outside_temperature_override->add_on_state_callback([=](float temperature) {

--- a/components/otgw/otgw.cpp
+++ b/components/otgw/otgw.cpp
@@ -326,11 +326,23 @@ void OpenthermGateway::parse_line(std::string const &line) {
       }
       break;
     }
-    case 9:
-      if (line[0] != 'T') {
-        this->remote_override_room_setpoint.publish_state(parse_float(data));
+    case 9: {
+      float temperature = parse_float(data);
+      if (line[0] == 'B') {
+        this->remote_override_room_setpoint.publish_state(temperature);
+      }
+
+      if (line[0] == 'A') {
+        if (_room_thermostat != nullptr) {
+          if (temperature == 0) {
+            _room_thermostat->set_mode(climate::ClimateMode::CLIMATE_MODE_AUTO);
+          } else {
+            _room_thermostat->set_mode(climate::ClimateMode::CLIMATE_MODE_HEAT);
+          }
+        }
       }
       break;
+    }
     case 16: {
       float temperature = parse_float(data);
       this->room_setpoint_1.publish_state(temperature);

--- a/components/otgw/otgw.cpp
+++ b/components/otgw/otgw.cpp
@@ -551,6 +551,13 @@ void OpenthermGateway::set_reset_service_request_button(OpenthermGatewayButton *
   });
 }
 
+void OpenthermGateway::set_hot_water_push_button(OpenthermGatewayButton *butt) {
+  _hot_water_push = butt;
+  _hot_water_push->set_callback([=]() {
+    queue_command("HW", "P");
+  });
+}
+
 bool OpenthermGateway::set_heating_circuit_setpoint(HeatingCircuit &heating_circuit, optional<float> temperature) {
   heating_circuit.time_of_last_command = millis();
 

--- a/components/otgw/otgw.h
+++ b/components/otgw/otgw.h
@@ -52,6 +52,7 @@ class OpenthermGateway : public Component, public uart::UARTDevice {
   time::RealTimeClock *_time_source{nullptr};
 
   bool _override_thermostat{false};
+  bool _hot_water_temperature_reported{false};
 
  public:
   OptionalComponent<text_sensor::TextSensor> slave_opentherm_version;

--- a/components/otgw/otgw.h
+++ b/components/otgw/otgw.h
@@ -51,7 +51,6 @@ class OpenthermGateway : public Component, public uart::UARTDevice {
   sensor::Sensor *_outside_temperature_override{nullptr};
   time::RealTimeClock *_time_source{nullptr};
 
-  bool _override_thermostat{false};
   bool _hot_water_temperature_reported{false};
 
  public:
@@ -136,7 +135,6 @@ class OpenthermGateway : public Component, public uart::UARTDevice {
   void set_hot_water(OpenthermGatewayClimate *clim);
   void set_heating_circuit_1(OpenthermGatewayClimate *clim);
   void set_heating_circuit_2(OpenthermGatewayClimate *clim);
-  void set_override_thermostat(bool value);
   void set_outside_temperature_override(sensor::Sensor *sens);
   void set_time_source(time::RealTimeClock *time);
   void set_reset_service_request_button(OpenthermGatewayButton *butt);

--- a/components/otgw/otgw.h
+++ b/components/otgw/otgw.h
@@ -44,6 +44,7 @@ class OpenthermGateway : public Component, public uart::UARTDevice {
   OpenthermGatewayClimate *_room_thermostat{nullptr};
   OpenthermGatewayClimate *_hot_water{nullptr};
   OpenthermGatewayButton *_reset_service_request{nullptr};
+  OpenthermGatewayButton *_hot_water_push{nullptr};
   optional<HeatingCircuit> _heating_circuit_1;
   optional<HeatingCircuit> _heating_circuit_2;
 
@@ -138,6 +139,7 @@ class OpenthermGateway : public Component, public uart::UARTDevice {
   void set_outside_temperature_override(sensor::Sensor *sens);
   void set_time_source(time::RealTimeClock *time);
   void set_reset_service_request_button(OpenthermGatewayButton *butt);
+  void set_hot_water_push_button(OpenthermGatewayButton *butt);
 
  protected:
   static constexpr uint16_t MAX_BUFFER_SIZE = 128;

--- a/components/otgw/otgw.h
+++ b/components/otgw/otgw.h
@@ -162,10 +162,11 @@ class OpenthermGateway : public Component, public uart::UARTDevice {
 
   climate::ClimateAction calculate_climate_action(bool flame, bool heating);
   bool set_room_setpoint(float temperature);
-  bool set_heating_circuit_setpoint(HeatingCircuit &heating_circuit, optional<float> temperature);
-  bool refresh_heating_circuit_setpoint(optional<HeatingCircuit> &heating_circuit);
-  bool set_heating_circuit_target_temperature(optional<HeatingCircuit> &heating_circuit, float temperature);
-  bool set_heating_circuit_action(optional<HeatingCircuit> &heating_circuit, bool flame, bool heating);
+  void set_heating_circuit_target(HeatingCircuit &heating_circuit);
+  void set_heating_circuit_mode(HeatingCircuit &heating_circuit);
+  void refresh_heating_circuit_target(optional<HeatingCircuit> &heating_circuit);
+  bool set_heater_climate_target_temperature(optional<HeatingCircuit> &heating_circuit, float temperature);
+  bool set_heater_climate_action(optional<HeatingCircuit> &heating_circuit, bool flame, bool heating);
 
  public:
   OpenthermGateway(uart::UARTComponent *parent) : uart::UARTDevice(parent) {

--- a/example_otgw.yaml
+++ b/example_otgw.yaml
@@ -22,7 +22,6 @@ external_components:
       path: components
 
 otgw:
-  override_thermostat: true
   time_source: hass_time
 
 uart:


### PR DESCRIPTION
The hot water climate component now has three modes:
OFF: Hot water blocking will be requested
AUTO: Water will be heated when the tap opens
HEAT: Water will always be kept hot

The heating circuits climate components now also have an AUTO mode. When put in AUTO mode, they will relinquish control to the thermostat.

The room climate component now also has an AUTO mode. When put in AUTO mode, it will allow the thermostat to override the target temperature whenever it wants to (for example, because it is on a schedule).